### PR TITLE
Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+IndentWidth: 4


### PR DESCRIPTION
This commit adds a simple Clang-Format file to simplify consistent
formatting. For now, it is just based on the LLVM style but with an
indentation of 4 spaces, which seems to match the current style of the
source code reasonably well.