### PR TITLE
Add Docker Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
 .PHONY : clean all test
 
 CFLAGS=-g -O3
-LDFLAGS=-static -lutil
+LDFLAGS=
+DISTFILES=SMT-COMP-2021-trace-executor.tar.gz
 
-all: smtlib2_trace_executor SMT-COMP-2020-trace-executor.tar.xz
+all: $(DISTFILES)
 
 smtlib2_trace_executor: smtlib2_trace_executor.o
 	$(CC) $< -o $@ $(LDFLAGS)
 
 clean:
-	rm -f smtlib2_trace_executor.o smtlib2_trace_executor SMT-COMP-2020-trace-executor.tar.xz
+	rm -f smtlib2_trace_executor.o smtlib2_trace_executor $(DISTFILES) test_solver_log.txt
 
-SMT-COMP-2020-trace-executor.tar.xz: starexec_run_default smtlib2_trace_executor
-	tar -cJf $@ $^
+SMT-COMP-2021-trace-executor.tar.gz: starexec_run_default smtlib2_trace_executor
+	tar -czf $@ $^
 
 test: smtlib2_trace_executor
 	test/run_tests.sh ./smtlib2_trace_executor
+
+dist: $(DISTFILES)
+	cp $(DISTFILES) /dist
+

--- a/README.md
+++ b/README.md
@@ -36,3 +36,41 @@ compares the output against the expected output in the corresponding
 `*.smt2.expect` file. The `test_solver.sh` scripts in the subdirectories of
 `test/` simulate solvers and for each test case, `make test` uses the
 `test_solver.sh` script in the same directory as the input.
+
+## Docker Build
+
+To build an executable suitable for use on StarExec, you need to use a
+centos:7 image.  We provide docker scripts to help.
+
+```sh
+cd docker
+./create-docker.sh
+./build-docker.sh
+```
+
+This creates a tar.gz file containing the binary trace executor and
+the starexec run script.
+
+## Wrapping your Solver
+
+The pre- and post-processors of starexec are not suitable for the
+incremental track where the trace-executor needs to interact with your
+solver.  Instead the solution for SMT-COMP is to add the
+trace executor to the solver binaries and upload a wrapped solver.
+Note that in the competition the SMT-COMP organizers will wrap your
+solver.  These instructions are meant to help solver authors to test
+their solvers on starexec before the competition.
+
+To wrap your solver, first follow the above instructions for the
+Docker build or download the released tar archive.  Then rename your
+solver's start script and extract the tar archive.
+
+```sh
+cd mysolver/bin
+mv starexec_run_* original_starexec_run_default
+tar -xzf .../SMT-COMP-20*-trace-executor.tar.gz
+```
+
+Upload the wrapped solver to starexec.  Note that the wrapped solver
+can only be used in the incremental track with the incremental
+scrambler and post-processor.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+RUN yum -y install gcc gcc-c++ make flex bison glibc-static libstdc++-static python3 cython git
+
+WORKDIR /smtcomp
+COPY ./trace-executor ./trace-executor

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker run -v $(pwd):/dist:z smtcomp make -C trace-executor dist
+docker run -v $(pwd):/dist:z smtcomp sh -c "chown $(id -u):$(id -g) /dist/*.tar.gz"

--- a/docker/create-docker.sh
+++ b/docker/create-docker.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+rm -rf trace-executor
+mkdir ./trace-executor
+cp -a ../[^d]* trace-executor
+make -C trace-executor clean
+
+docker build -t smtcomp .


### PR DESCRIPTION
Added directory similarly to how we did it for the post-processors to create an image suitable for starexec.

Changed Makefile to create tar.gz instead of xz (not really necessary, but the post-processor/scrambler need to be tar.gz for direct upload).  Added the dist rule for docker.  Changed year to 2021.  Don't compile static anymore.